### PR TITLE
Sitecore PSE/JSS and SXA variants on top of the base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Build your own Docker images out of every released Sitecore version since 8.2 re
 
 ## Changelog
 
+- [Changes] Add PSE/JSS and SXA docker compose test files
+- [Changes] Add Variants build support
+- [Changes] Add Variants support; Sitecore Experience Accelerator (SXA)
+- [Changes] Add Variants support; Sitecore JavaScript Services (JSS)
+- [Changes] Add Variants support; sitecore powershell extensions (PSE)
 - [Changed] Sitecore 9.1.1 IIS app pools now runs as `LocalSystem` so they are allowed to write to volume mounts on Windows Server 2016/2019 hosts.
 - [Fixed] Sitecore Solr images on 1809 now runs as `ContainerAdministrator` again to fix access denied errors, see [#27](https://github.com/sitecoreops/sitecore-images/issues/27). Thanks [@joostmeijles](https://github.com/joostmeijles) :+1:
 - [**Breaking**] Sitecore 9.1.1 XM images renamed **back** to `xm1`, see [#28](https://github.com/sitecoreops/sitecore-images/issues/28). Thanks [@sergeyshushlyapin](https://github.com/sergeyshushlyapin) :+1:
@@ -210,9 +215,19 @@ Import-Module (Join-Path $PSScriptRoot "\modules\SitecoreImageBuilder") -Force
 
 # Build and push
 SitecoreImageBuilder\Invoke-Build `
-    -Path (Join-Path $PSScriptRoot "\images") `
+    -Path (Join-Path $PSScriptRoot "\images") ` 
     -InstallSourcePath "PATH TO WHERE YOU KEEP ALL SITECORE ZIP FILES AND LICENSE.XML" `
     -Registry "YOUR REGISTRY NAME" ` # On Docker Hub it's your username or organization, else it's the hostname of your private registry.
     -Tags "*" ` # optional (default "*"), set to for example "sitecore-openjdk:*-1803", "sitecore-*:9.0.1*1803" to only build 9.0.x images on 1803.
     -PushMode "WhenChanged" # optional (default "WhenChanged"), can also be "Never" or "Always".
+
+# Build and push variants
+SitecoreImageBuilder\Invoke-Build `
+    -Path (Join-Path $PSScriptRoot "\variants") ` 
+    -InstallSourcePath "PATH TO WHERE YOU KEEP ALL SITECORE ZIP FILES AND LICENSE.XML" `
+    -Registry "YOUR REGISTRY NAME" ` # On Docker Hub it's your username or organization, else it's the hostname of your private registry.
+    -Tags "*" ` # optional (default "*"), set to for example "sitecore-openjdk:*-1803", "sitecore-*:9.0.1*1803" to only build 9.0.x images on 1803.
+    -PushMode "WhenChanged" # optional (default "WhenChanged"), can also be "Never" or "Always".
+
+
 ```

--- a/images/9.1.1 rev. 002459/windowsservercore-ltsc2019/sitecore-xm1-sqldev/Dockerfile
+++ b/images/9.1.1 rev. 002459/windowsservercore-ltsc2019/sitecore-xm1-sqldev/Dockerfile
@@ -46,6 +46,7 @@ COPY . ${INSTALL_PATH}
 RUN New-Item -Path $env:DATA_PATH -ItemType Directory | Out-Null; `
     & (Join-Path $env:INSTALL_PATH "Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
     & (Join-Path $env:INSTALL_PATH "Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; `
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; `
     Get-ChildItem -Path $env:INSTALL_PATH -Exclude "*.mdf", "*.ldf" | Remove-Item -Force;
 
 COPY Boot.ps1 .

--- a/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
+++ b/modules/SitecoreImageBuilder/SitecoreImageBuilder.psm1
@@ -31,6 +31,14 @@ function Invoke-Build
     $priorities.Add("^sitecore-xp-base:(.*)$", 110)
     $priorities.Add("^sitecore-xp-xconnect:(.*)$", 120)
     $priorities.Add("^sitecore-openjdk:(.*)$", 130)
+    $priorities.Add("^sitecore-xp-sqldev:(.*)$", 140)
+    $priorities.Add("^sitecore-xm1-pse-(.*)-sqldev:(.*)$", 150)
+    $priorities.Add("^sitecore-xp-pse-(.*)-sqldev:(.*)$", 160)
+    $priorities.Add("^sitecore-xm-sqldev:(.*)$", 170)
+    $priorities.Add("^sitecore-xp-pse-(.*)-standalone:(.*)$", 180);
+    $priorities.Add("^sitecore-xm1-pse-(.*)-cm:(.*)$", 190);
+    
+    
     $priorities.Add("^(.*)$", $defaultPriority)
     
     # Find out what to build
@@ -64,8 +72,8 @@ function Invoke-Build
 
     # Reorder specs, priorities goes first
     $specs = [System.Collections.ArrayList]@()
-    $specs.AddRange(($unsortedSpecs | Where-Object { $_.Priority -lt $defaultPriority } | Sort-Object -Property Priority))
-    $specs.AddRange(($unsortedSpecs | Where-Object { $_.Priority -eq $defaultPriority }))
+    $specs.AddRange(@($unsortedSpecs | Where-Object { $_.Priority -lt $defaultPriority } | Sort-Object -Property Priority))
+    $specs.AddRange(@($unsortedSpecs | Where-Object { $_.Priority -eq $defaultPriority }))
 
     # Print results
     $specs | Select-Object -Property Tag, Include, Priority, Base | Format-Table
@@ -145,7 +153,7 @@ function Invoke-Build
         }
         else
         {
-            docker image build --isolation "hyperv" --tag $tag $spec.Path
+            docker image build --isolation "hyperv" --tag $tag $spec.Path 
         }
 
         $LASTEXITCODE -ne 0 | Where-Object { $_ } | ForEach-Object { throw "Failed." }

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.jss.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.jss.yml
@@ -1,0 +1,39 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xm1-jss-10.0.1-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xm1-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  cd:
+    image: sitecore-xm1-jss-10.0.1-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+
+  cm:
+    image: sitecore-xm1-jss-10.0.1-cm:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.pse.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.pse.yml
@@ -1,0 +1,39 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xm1-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  cd:
+    image: sitecore-xm1-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+
+  cm:
+    image: sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.sxa.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xm.sxa.yml
@@ -1,0 +1,39 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xm1-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  cd:
+    image: sitecore-xm1-sxa-1.8.1-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+
+  cm:
+    image: sitecore-xm1-sxa-1.8.1-cm:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.jss.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.jss.yml
@@ -1,0 +1,68 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xp-jss-10.0.1-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xp-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  xconnect:
+    image: sitecore-xp-xconnect:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
+    mem_limit: 1GB
+    links:
+      - sql
+      - solr
+
+  xconnect-automationengine:
+    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - xconnect
+
+  xconnect-indexworker:
+    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - solr
+
+  cd:
+    image: sitecore-xp-jss-10.0.1-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+      - xconnect
+
+  cm:
+    image: sitecore-xp-jss-10.0.1-standalone:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr
+      - xconnect

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.pse.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.pse.yml
@@ -1,0 +1,68 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xp-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  xconnect:
+    image: sitecore-xp-xconnect:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
+    mem_limit: 1GB
+    links:
+      - sql
+      - solr
+
+  xconnect-automationengine:
+    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - xconnect
+
+  xconnect-indexworker:
+    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - solr
+
+  cd:
+    image: sitecore-xp-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+      - xconnect
+
+  cm:
+    image: sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr
+      - xconnect

--- a/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.sxa.yml
+++ b/tests/9.1.1 rev. 002459/ltsc2019/docker-compose.xp.sxa.yml
@@ -1,0 +1,68 @@
+version: '2.4'
+
+services:
+
+  sql:
+    image: sitecore-xp-sxa-1.8.1-sqldev:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\sql:C:\Data
+    mem_limit: 2GB
+    ports:
+      - "44010:1433"
+
+  solr:
+    image: sitecore-xp-solr:9.1.1-nanoserver-1809
+    volumes:
+      - .\data\solr:C:\Data
+    mem_limit: 1GB
+    ports:
+      - "44011:8983"
+
+  xconnect:
+    image: sitecore-xp-xconnect:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect:C:\inetpub\xconnect\App_Data\logs
+    mem_limit: 1GB
+    links:
+      - sql
+      - solr
+
+  xconnect-automationengine:
+    image: sitecore-xp-xconnect-automationengine:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-automationengine:C:\AutomationEngine\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - xconnect
+
+  xconnect-indexworker:
+    image: sitecore-xp-xconnect-indexworker:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\xconnect-indexworker:C:\IndexWorker\App_Data\logs
+    mem_limit: 500MB
+    links:
+      - sql
+      - solr
+
+  cd:
+    image: sitecore-xp-sxa-1.8.1-cd:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cd:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44002:80"
+    links:
+      - sql
+      - solr
+      - xconnect
+
+  cm:
+    image: sitecore-xp-sxa-1.8.1-standalone:9.1.1-windowsservercore-ltsc2019
+    volumes:
+      - .\data\cm:C:\inetpub\sc\App_Data\logs
+    ports:
+      - "44001:80"
+    links:
+      - sql
+      - solr
+      - xconnect

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/Dockerfile
@@ -1,0 +1,26 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_JSS = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318.scwdp.zip'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_JSS)).Path -NewName 'jss.zip';
+
+# # Runtime
+FROM sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/jss.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\jss.zip') `
+     -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-jss-10.0.1-cm:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-cm/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Boot.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Dockerfile
@@ -1,0 +1,35 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+ENV DATA_PATH='c:/data/'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force; `
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; ` 
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+COPY Boot.ps1 .
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Install-Databases.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $DataPath
+$server.Properties["DefaultLog"].Value = $DataPath
+$server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss-10.0.1-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-jss-10.0.1-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/Dockerfile
@@ -1,0 +1,26 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_JSS = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318 CD.scwdp.zip'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_JSS)).Path -NewName 'jss.zip';
+
+# Runtime
+FROM sitecore-xm1-cd:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/jss.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\jss.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-jss-10.0.1-cd:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318 CD.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-jss.10.0.1-cd/install-package.json
@@ -1,0 +1,56 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/Dockerfile
@@ -1,0 +1,26 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_PSE = 'Sitecore PowerShell Extensions-5.0.scwdp.zip'; `
+     $env:INSTALL_TEMP = 'C:\\install'; ` 
+     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_PSE)).Path -NewName 'spe.zip';
+
+# Runtime
+FROM sitecore-xm1-cm:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder ["/install/install-package.json", "/install/spe.zip", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `  
+     $env:INSTALL_TEMP = 'C:\\install'; `
+     Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\spe.zip') `
+     -Sitename $env:SITENAME ; ` 
+     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore PowerShell Extensions-5.0.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-cm/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Boot.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$SqlHostname,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Preparing Sitecore databases..."
+
+# See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Dockerfile
@@ -1,0 +1,32 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xm1-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force ; ` 
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; `
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -SqlHostname $env:SQL_HOSTNAME -DatabasePrefix $env:DB_PREFIX;

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Install-Databases.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+# detach DB
+# Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+#     $databaseName = $_.BaseName.Replace("_Primary", "")
+
+#     Write-Host "### Detach: $databaseName"
+
+#     Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+# }
+
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+# $server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+# $server.Properties["DefaultFile"].Value = $DataPath
+# $server.Properties["DefaultLog"].Value = $DataPath
+# $server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-pse-5.0-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore PowerShell Extensions-5.0.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 COPY . /install/
 
 # Expand zips, prepare SIF config and WDP package
-RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318.scwdp.zip'; `
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore Experience Accelerator XM 1.8.1 rev. 190319 for 9.1.1.scwdp.zip'; `
     $env:INSTALL_TEMP = 'C:\\install'; `
     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
 

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/Dockerfile
@@ -1,0 +1,26 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318.scwdp.zip'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
+
+# # Runtime
+FROM sitecore-xm1-pse-5.0-cm:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/sxa.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\sxa.zip') `
+     -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-sxa-1.8.1-cm:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator XM 1.8.1 rev. 190319 for 9.1.1.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-cm/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Boot.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Dockerfile
@@ -1,0 +1,35 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xm1-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+ENV DATA_PATH='c:/data/'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force; `
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; ` 
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+COPY Boot.ps1 .
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Install-Databases.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $DataPath
+$server.Properties["DefaultLog"].Value = $DataPath
+$server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa-1.8.1-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-sxa-1.8.1-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator XM 1.8.1 rev. 190319 for 9.1.1.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 COPY . /install/
 
 # Expand zips, prepare SIF config and WDP package
-RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318 CD.scwdp.zip'; `
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore Experience Accelerator XM 1.8.1 rev. 190319 for 9.1.1 CD.scwdp.zip'; `
     $env:INSTALL_TEMP = 'C:\\install'; `
     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
 

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/Dockerfile
@@ -1,0 +1,26 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XM 11.0.1 rev. 190318 CD.scwdp.zip'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
+
+# Runtime
+FROM sitecore-xm1-cd:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/sxa.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\sxa.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xm1-sxa-1.8.1-cd:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator XM 1.8.1 rev. 190319 for 9.1.1 CD.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xm1-sxa.1.8.1-cd/install-package.json
@@ -1,0 +1,56 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Boot.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$SqlHostname,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Preparing Sitecore databases..."
+
+# See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Dockerfile
@@ -1,0 +1,32 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force; `
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; ` 
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -SqlHostname $env:SQL_HOSTNAME -DatabasePrefix $env:DB_PREFIX;

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Install-Databases.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+# detach DB
+# Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+#     $databaseName = $_.BaseName.Replace("_Primary", "")
+
+#     Write-Host "### Detach: $databaseName"
+
+#     Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+# }
+
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+# $server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+# $server.Properties["DefaultFile"].Value = $DataPath
+# $server.Properties["DefaultLog"].Value = $DataPath
+# $server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-jss-10.0.1-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_JSS = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip'; `
+    $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_JSS)).Path -NewName 'jss.zip';
+
+# # Runtime
+FROM sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/jss.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\jss.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-jss-10.0.1-standalone:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss-10.0.1-standalone/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_JSS = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318 CD.scwdp.zip'; `
+    $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_JSS)).Path -NewName 'jss.zip';
+
+# Runtime
+FROM sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/jss.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\jss.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-jss-10.0.1-cd:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318 CD.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-jss.10.0.1-cd/install-package.json
@@ -1,0 +1,56 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Boot.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$SqlHostname,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Preparing Sitecore databases..."
+
+# See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Dockerfile
@@ -1,0 +1,32 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xp-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force ; ` 
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; `
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -SqlHostname $env:SQL_HOSTNAME -DatabasePrefix $env:DB_PREFIX;

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Install-Databases.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+# detach DB
+# Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+#     $databaseName = $_.BaseName.Replace("_Primary", "")
+
+#     Write-Host "### Detach: $databaseName"
+
+#     Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+# }
+
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+# $server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+# $server.Properties["DefaultFile"].Value = $DataPath
+# $server.Properties["DefaultLog"].Value = $DataPath
+# $server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore PowerShell Extensions-5.0.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_PSE = 'Sitecore PowerShell Extensions-5.0.scwdp.zip'; `
+     $env:SITENAME = 'sc'; `
+     $env:INSTALL_TEMP = 'C:\\install'; ` 
+     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_PSE)).Path -NewName 'spe.zip';
+
+# Runtime
+FROM sitecore-xp-standalone:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder ["/install/install-package.json", "/install/spe.zip", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+     $env:INSTALL_TEMP = 'C:\\install'; `
+     Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\spe.zip') `
+     -Sitename $env:SITENAME ; `
+     Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore PowerShell Extensions-5.0.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-pse-5.0-standalone/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Boot.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Boot.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$SqlHostname,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$DatabasePrefix
+)
+
+$noDatabases = (Get-ChildItem -Path $DataPath -Filter "*.mdf") -eq $null
+
+if ($noDatabases)
+{
+    Write-Host "### Sitecore databases not found in '$DataPath', seeding clean databases..."
+
+    Get-ChildItem -Path $InstallPath | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination $DataPath
+    }
+}
+else
+{
+    Write-Host "### Existing Sitecore databases found in '$DataPath'..."
+}
+
+Get-ChildItem -Path $DataPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+Write-Host "### Preparing Sitecore databases..."
+
+# See http://jonnekats.nl/2017/sql-connection-issue-xconnect/ for details...
+Invoke-Sqlcmd -Query ("EXEC sp_MSforeachdb 'IF charindex(''{0}'', ''?'' ) = 1 BEGIN EXEC [?]..sp_changedbowner ''sa'' END'" -f $env:DB_PREFIX)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.ShardMapManager].[__ShardManagement].[ShardsGlobal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard0].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+Invoke-Sqlcmd -Query ("UPDATE [{0}_Xdb.Collection.Shard1].[__ShardManagement].[ShardsLocal] SET ServerName = '{1}'" -f $env:DB_PREFIX, $SqlHostname)
+
+Write-Host "### Sitecore databases ready!"
+
+# Call Start.ps1 from the base image https://github.com/Microsoft/mssql-docker/blob/master/windows/mssql-server-windows-developer/dockerfile
+& C:\Start.ps1 -sa_password $env:sa_password -ACCEPT_EULA $env:ACCEPT_EULA -attach_dbs \"$env:attach_dbs\" -Verbose

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Dockerfile
@@ -1,0 +1,32 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# # Runtime
+FROM sitecore-xp-pse-5.0-sqldev:9.1.1-windowsservercore-ltsc2019 as final
+
+HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
+
+# # ABOVE HERE SHOULD BE REMOVE WHEN A ltsc2019 VERSION IS RELEASED
+ENV ACCEPT_EULA=Y
+ENV sa_password='HASH-epsom-sunset-cost7!'
+ENV DB_PREFIX='sc'
+ENV INSTALL_PATH='c:/install/'
+ENV DATA_PATH='c:/data/'
+ENV SQL_HOSTNAME='sql'
+
+ADD https://dist.nuget.org/win-x86-commandline/v4.1.0/nuget.exe C:\\Windows\\nuget.exe
+
+RUN New-Item -Path 'C:/tools' -ItemType Directory | Out-Null; `
+    & nuget install Microsoft.Data.Tools.Msbuild -Version 10.0.61710.120 -OutputDirectory c:/tools
+
+COPY . ${INSTALL_PATH}
+
+RUN & (Join-Path $env:INSTALL_PATH "\\Extract-Databases.ps1") -Path $env:INSTALL_PATH; `
+    & (Join-Path $env:INSTALL_PATH "\\Install-Databases.ps1") -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -DatabasePrefix $env:DB_PREFIX; ` 
+    Move-Item -Path (Join-Path $env:INSTALL_PATH "\\Boot.ps1") -Destination 'C:\\Boot.ps1' -Force; `
+    Get-ChildItem -Path $env:INSTALL_PATH -Exclude '*.mdf', '*.ldf' -Recurse -Force | Remove-Item -Recurse -Force; ` 
+    Remove-Item -Path 'C:\\tools' -Recurse -Force; 
+
+CMD C:/Boot.ps1 -InstallPath $env:INSTALL_PATH -DataPath $env:DATA_PATH -SqlHostname $env:SQL_HOSTNAME -DatabasePrefix $env:DB_PREFIX;

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Extract-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Extract-Databases.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( {Test-Path $_ -PathType 'Container'})] 
+    [string]$Path
+)
+
+Add-Type -Assembly "System.IO.Compression.FileSystem";
+
+# extract mmodule
+Get-ChildItem -Path $Path -Filter "*.zip" | ForEach-Object { 
+    Write-Host "Extract module: '$_.FullName'"
+    Expand-Archive  $_.FullName -DestinationPath (Join-Path $Path $_.GetHashCode())
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Install-Databases.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Install-Databases.ps1
@@ -1,0 +1,73 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$InstallPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateScript( { Test-Path $_ -PathType 'Container' })] 
+    [string]$DataPath,
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()] 
+    [string]$DatabasePrefix
+)
+
+[System.Reflection.Assembly]::LoadWithPartialName("Microsoft.SqlServer.SMO") | Out-Null
+
+$server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+$server.Properties["DefaultFile"].Value = $InstallPath
+$server.Properties["DefaultLog"].Value = $InstallPath
+$server.Alter()
+
+# detach DB
+# Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+#     $databaseName = $_.BaseName.Replace("_Primary", "")
+
+#     Write-Host "### Detach: $databaseName"
+
+#     Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+# }
+
+
+Write-Host "install path" + $InstallPath
+
+$sqlPackageExePath = Get-Item "C:\tools\*\lib\net46\SqlPackage.exe" | Select-Object -Last 1 -Property FullName -ExpandProperty FullName
+
+# attach
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+    $mdfPath = $_.FullName
+    $ldfPath = $mdfPath.Replace(".mdf", ".ldf")
+    $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '$databaseName') BEGIN EXEC sp_detach_db [$databaseName] END;CREATE DATABASE [$databaseName] ON (FILENAME = N'$mdfPath'), (FILENAME = N'$ldfPath') FOR ATTACH;"
+
+    Write-Host "### Attaching '$databaseName'..."
+
+    Invoke-Sqlcmd -Query $sqlcmd
+}
+
+# do modules
+$TextInfo = (Get-Culture).TextInfo
+Get-ChildItem -Path $InstallPath -Include "core.dacpac", "master.dacpac" -Recurse | ForEach-Object { 
+
+    $dacpacPath = $_.FullName
+    $databaseName = "$DatabasePrefix`_" + $TextInfo.ToTitleCase($_.BaseName)
+
+    # do
+    Write-Host "install module path: $InstallPath dacpac: $dacpacPath dbname: $databaseName"
+
+    # Install
+    & $sqlPackageExePath /a:Publish /sf:$dacpacPath /tdn:$databaseName /tsn:$env:COMPUTERNAME /q    
+} 
+
+# detach DB
+Get-ChildItem -Path $InstallPath -Filter "*.mdf" | ForEach-Object {
+    $databaseName = $_.BaseName.Replace("_Primary", "")
+
+    Write-Host "### Detach: $databaseName"
+
+    Invoke-Sqlcmd -Query "EXEC MASTER.dbo.sp_detach_db @dbname = N'$databaseName', @keepfulltextindexfile = N'false'"
+}
+
+# $server = New-Object Microsoft.SqlServer.Management.Smo.Server($env:COMPUTERNAME)
+# $server.Properties["DefaultFile"].Value = $DataPath
+# $server.Properties["DefaultLog"].Value = $DataPath
+# $server.Alter()

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Start.ps1
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/Start.ps1
@@ -1,0 +1,80 @@
+# The script sets the sa password and start the SQL Service
+# Also it attaches additional database from the disk
+# The format for attach_dbs
+
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$sa_password,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ACCEPT_EULA,
+
+    [Parameter(Mandatory = $false)]
+    [string]$attach_dbs
+)
+
+
+if ($ACCEPT_EULA -ne "Y" -And $ACCEPT_EULA -ne "y")
+{
+    Write-Verbose "ERROR: You must accept the End User License Agreement before this container can start."
+    Write-Verbose "Set the environment variable ACCEPT_EULA to 'Y' if you accept the agreement."
+
+    exit 1
+}
+
+# start the service
+Write-Verbose "Starting SQL Server"
+start-service MSSQLSERVER
+
+if ($sa_password -eq "_")
+{
+    if (Test-Path $env:sa_password_path)
+    {
+        $sa_password = Get-Content -Raw $secretPath
+    }
+    else
+    {
+        Write-Verbose "WARN: Using default SA password, secret file not found at: $secretPath"
+    }
+}
+
+if ($sa_password -ne "_")
+{
+    Write-Verbose "Changing SA login credentials"
+    $sqlcmd = "ALTER LOGIN sa with password=" + "'" + $sa_password + "'" + ";ALTER LOGIN sa ENABLE;"
+    & sqlcmd -Q $sqlcmd
+}
+
+$attach_dbs_cleaned = $attach_dbs.TrimStart('\\').TrimEnd('\\')
+
+$dbs = $attach_dbs_cleaned | ConvertFrom-Json
+
+if ($null -ne $dbs -And $dbs.Length -gt 0)
+{
+    Write-Verbose "Attaching $($dbs.Length) database(s)"
+	    
+    Foreach ($db in $dbs) 
+    {            
+        $files = @();
+        Foreach ($file in $db.dbFiles)
+        {
+            $files += "(FILENAME = N'$($file)')";           
+        }
+
+        $files = $files -join ","
+        $sqlcmd = "IF EXISTS (SELECT 1 FROM SYS.DATABASES WHERE NAME = '" + $($db.dbName) + "') BEGIN EXEC sp_detach_db [$($db.dbName)] END;CREATE DATABASE [$($db.dbName)] ON $($files) FOR ATTACH;"
+
+        Write-Verbose "Invoke-Sqlcmd -Query $($sqlcmd)"
+        & sqlcmd -Q $sqlcmd
+    }
+}
+
+Write-Verbose "Started SQL Server."
+
+$lastCheck = (Get-Date).AddSeconds(-2) 
+while ($true) 
+{ 
+    Get-EventLog -LogName Application -Source "MSSQL*" -After $lastCheck | Select-Object TimeGenerated, EntryType, Message	 
+    $lastCheck = Get-Date 
+    Start-Sleep -Seconds 2 
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-sqldev/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-sxa-1.8.1-sqldev:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator 1.8.1 rev. 190319 for 9.1.1.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip'; `
+    $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
+
+# # Runtime
+FROM sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/sxa.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\sxa.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 COPY . /install/
 
 # Expand zips, prepare SIF config and WDP package
-RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318.scwdp.zip'; `
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore Experience Accelerator 1.8.1 rev. 190319 for 9.1.1.scwdp.zip'; `
     $env:SITENAME = 'sc'; `
     $env:INSTALL_TEMP = 'C:\\install'; `
     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-sxa-1.8.1-standalone:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator 1.8.1 rev. 190319 for 9.1.1.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa-1.8.1-standalone/install-package.json
@@ -1,0 +1,64 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        },
+                        {
+                            "Name": "Core Admin Connection String",
+                            "Value": "[parameter('SqlCoreUser')]"
+                        },
+                        {
+                            "Name": "Master Admin Connection String",
+                            "Value": "[parameter('SqlMasterUser')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/Dockerfile
@@ -1,0 +1,28 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as builder
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+COPY . /install/
+
+# Expand zips, prepare SIF config and WDP package
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318 CD.scwdp.zip'; `
+    $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';
+
+# Runtime
+FROM sitecore-xp-pse-5.0-standalone:9.1.1-windowsservercore-ltsc2019 as final
+
+COPY --from=builder [ "/install/sxa.zip", "/install/install-package.json", "/install/" ]
+
+# Install Sitecore, apply tweaks and cleanup
+RUN $env:SITENAME = 'sc'; `
+    $env:INSTALL_TEMP = 'C:\\install'; `
+    Install-SitecoreConfiguration -Path (Join-Path $env:INSTALL_TEMP '\\install-package.json') -Package (Join-Path $env:INSTALL_TEMP '\\sxa.zip') `
+    -Sitename $env:SITENAME ; `
+    Remove-Item -Path $env:INSTALL_TEMP -Force -Recurse; 
+
+
+# ServiceMonitor needs to point to the Application Pool that Sitecore runs in instead of the default one, to support environment variables
+ENTRYPOINT ["C:\\ServiceMonitor.exe", "w3svc", "sc"]

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/Dockerfile
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 COPY . /install/
 
 # Expand zips, prepare SIF config and WDP package
-RUN $env:SIF_PACKAGE_SXA = 'Sitecore JavaScript Services Server for Sitecore 9.1.1 XP 11.0.1 rev. 190318 CD.scwdp.zip'; `
+RUN $env:SIF_PACKAGE_SXA = 'Sitecore Experience Accelerator 1.8.1 rev. 190319 for 9.1.1 CD.scwdp.zip'; `
     $env:SITENAME = 'sc'; `
     $env:INSTALL_TEMP = 'C:\\install'; `
     Rename-Item -Path (Resolve-Path (Join-Path $env:INSTALL_TEMP $env:SIF_PACKAGE_SXA)).Path -NewName 'sxa.zip';

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/build.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/build.json
@@ -1,0 +1,6 @@
+{
+    "tag": "sitecore-xp-sxa-1.8.1-cd:9.1.1-windowsservercore-ltsc2019",
+    "sources": [
+        "Sitecore Experience Accelerator 1.8.1 rev. 190319 for 9.1.1 CD.scwdp.zip"
+    ]
+}

--- a/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/install-package.json
+++ b/variants/9.1.1/ltsc2019/sitecore-xp-sxa.1.8.1-cd/install-package.json
@@ -1,0 +1,56 @@
+{
+    "Parameters": {
+        "Package": {
+            "Type": "string",
+            "Description": "The path to the Sitecore package."
+        },
+        "SiteName": {
+            "Type": "string",
+            "Description": "The url of the content management site."
+        },
+        "SqlCoreUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        },
+        "SqlMasterUser": {
+            "Type": "string",
+            "Description": "The path to the content management site.",
+            "DefaultValue": "<none>"
+        }
+    },
+    "Variables": {
+        "Site.PhysicalPath": "[joinpath(parameter('SitePath'),parameter('SiteName'))]",
+        "Site.Url": "[concat('https://',parameter('SiteName'))]"
+    },
+    "Tasks": {
+        "InstallSitecorePackage": {
+            "Type": "WebDeploy",
+            "Params": {
+                "Verb": "Sync",
+                "Arguments": {
+                    "Source": {
+                        "Package": "[resolvepath(parameter('Package'))]"
+                    },
+                    "Dest": "Auto",
+                    "SetParam": [
+                        {
+                            "Name": "Application Path",
+                            "Value": "[parameter('SiteName')]"
+                        }
+                    ],
+                    "EnableRule": "DoNotDelete",
+                    "UseChecksum": true,
+                    "Skip": [
+                        {
+                            "ObjectName": "dbFullSql"
+                        },
+                        {
+                            "ObjectName": "dbDacFx"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary
I'm working already a long time with the Sitecore docker-images, and the need for having Sitecore Powershell Extensions installed on top of the base image was growing. Because of this need, I start creating new base images with these modules installed on top of the base image. I did create a variant folder and start creating XM1 and XP configurations.
 
#Layers
1.)	Powershell Extensions (PSE)
2.)	Sitecore JavaScript Services (JSS)
3.)	Sitecore Experience Accelerator (SXA)
4.)	…

On top of each layer you can install another module; example commerce, commerce uses PSE and SXA OOTB.
I added also test docker compose files into the tests folder. 


